### PR TITLE
adding support for single end read data

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "rnaseq_samples_dir": "",
     "rnaseq_samples": "",
     "fastq_suffix": "fastq.gz",
+    "paired_end_read": "yes",
     "read1_identifier": "_1",
     "read2_identifier": "{{ cookiecutter.read1_identifier|replace('1', '2') }}",
     "ensembl_version": "84",

--- a/{{cookiecutter.project_name}}/functions.sh
+++ b/{{cookiecutter.project_name}}/functions.sh
@@ -20,13 +20,22 @@ function map_reads {
     star_tmp=${SAMPLE}.tmp
     mkdir ${star_tmp}
 
-    STAR --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_1_FILES} ${READ_2_FILES} --outFileNamePrefix ${star_tmp}/star --outSAMstrandField intronMotif --outSAMtype BAM SortedByCoordinate --readFilesCommand zcat
+
+    if [ -z "$READ_2_FILES" ]
+    then
+        #if read_2 files is empty, the input is single end read
+        STAR --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_1_FILES} --outFileNamePrefix ${star_tmp}/star --outSAMstrandField intronMotif --outSAMtype BAM SortedByCoordinate --readFilesCommand zcat
+    else
+        STAR --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_1_FILES} ${READ_2_FILES} --outFileNamePrefix ${star_tmp}/star --outSAMstrandField intronMotif --outSAMtype BAM SortedByCoordinate --readFilesCommand zcat
+
+    fi
 
     mv ${star_tmp}/starAligned.sortedByCoord.out.bam ${OUTPUT_DIR}/${SAMPLE}.bam
     mv ${star_tmp}/starLog.final.out ${OUTPUT_DIR}/${SAMPLE}.log.out
 
     rm -rf ${star_tmp}
 }
+
 
 function count_reads_for_features {
     NUM_THREADS=$1

--- a/{{cookiecutter.project_name}}/run_analysis.sh
+++ b/{{cookiecutter.project_name}}/run_analysis.sh
@@ -26,6 +26,7 @@ DIFF_EXPR_DIR=${RESULTS_DIR}/differential_expression
 NUM_THREADS=16
 
 SAMPLES="{{cookiecutter.rnaseq_samples}}"
+PAIRED_END_READ="{{cookiecutter.paired_end_read}}"
 
 ##### Record software version information
 
@@ -59,7 +60,11 @@ wait
 mkdir -p ${MAPPING_DIR}
 
 for sample in ${SAMPLES}; do
-    map_reads ${sample} ${STAR_INDEX} ${NUM_THREADS} $(listFiles , ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}) $(listFiles , ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}) ${MAPPING_DIR}
+    if [ $PAIRED_END_READ = "yes" ]; then
+        map_reads ${sample} ${STAR_INDEX} ${NUM_THREADS} $(listFiles , ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}) $(listFiles , ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}) ${MAPPING_DIR}
+    else
+        map_reads ${sample} ${STAR_INDEX} ${NUM_THREADS} $(listFiles , ${RNASEQ_DIR}/${sample}/*.{{cookiecutter.fastq_suffix}}) "" ${MAPPING_DIR}
+    fi
 done
 
 ##### Count mapped reads
@@ -79,15 +84,24 @@ done
 ##### Quantify transcript expression with Salmon
 mkdir -p ${SALMON_QUANT_DIR}
 
+
 for sample in ${SAMPLES}; do
-    salmon quant -i ${SALMON_INDEX} -l A -1 $(listFiles ' ' ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}) -2 $(listFiles ' ' ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}) -o ${SALMON_QUANT_DIR}/${sample} --seqBias --gcBias -p ${NUM_THREADS} -g ${GTF_FILE}
+    if [ $PAIRED_END_READ = "yes" ]; then
+        salmon quant -i ${SALMON_INDEX} -l A -1 $(listFiles ' ' ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}) -2 $(listFiles ' ' ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}) -o ${SALMON_QUANT_DIR}/${sample} --seqBias --gcBias -p ${NUM_THREADS} -g ${GTF_FILE}
+    else
+        salmon quant -i ${SALMON_INDEX} -l A -r $(listFiles ' ' ${RNASEQ_DIR}/${sample}/*.{{cookiecutter.fastq_suffix}}) -o ${SALMON_QUANT_DIR}/${sample} --seqBias --gcBias -p ${NUM_THREADS} -g ${GTF_FILE}
+   fi
 done
 
 ##### Quantify transcript expression with Kallisto
 mkdir -p ${KALLISTO_QUANT_DIR}
 
 for sample in ${SAMPLES}; do
-    kallisto quant -i ${KALLISTO_INDEX} -o ${KALLISTO_QUANT_DIR}/${sample} --bias --rf-stranded -t ${NUM_THREADS} $(ls -1 ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}} | sed -r 's/(.*)/\1 \1/' | sed -r 's/(.* .*){{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}/\1{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}/' | tr '\n' ' ')
+    if [ $PAIRED_END_READ = "yes" ]; then
+        kallisto quant -i ${KALLISTO_INDEX} -o ${KALLISTO_QUANT_DIR}/${sample} --bias --rf-stranded -t ${NUM_THREADS} $(ls -1 ${RNASEQ_DIR}/${sample}/*{{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}} | sed -r 's/(.*)/\1 \1/' | sed -r 's/(.* .*){{cookiecutter.read1_identifier}}.{{cookiecutter.fastq_suffix}}/\1{{cookiecutter.read2_identifier}}.{{cookiecutter.fastq_suffix}}/' | tr '\n' ' ')
+    else
+        kallisto quant -i ${KALLISTO_INDEX} -o ${KALLISTO_QUANT_DIR}/${sample} --bias --single -t ${NUM_THREADS} $(ls -1 ${RNASEQ_DIR}/${sample}/*.{{cookiecutter.fastq_suffix}} )
+    fi
 done
 
 ##### Gather all QC data


### PR DESCRIPTION
Adding a cookiecutter parameter 'paired_end_read', which by default is set to 'yes'. This affects the command to execute STAR, salmon and kallisto.

When 'paired_end_read' is set to 'no', the "read1_identifier" and "read2_identifier" parameters will be ignored during execution.

Tested with IP data(single end reads)/ Sargasso test data(paired end reads).