### PR TITLE
change featurecount test run files postfix, so it does not mess up the multiQC report.

### DIFF
--- a/{{cookiecutter.project_name}}/functions.sh
+++ b/{{cookiecutter.project_name}}/functions.sh
@@ -65,7 +65,7 @@ function count_reads_for_features_strand_test {
         tail -n +3 ${counts_tmp} | cut -f 1,7 > ${COUNTS_OUTPUT_FILE}.$i
 
         rm ${counts_tmp}
-        mv ${counts_tmp}.summary ${COUNTS_OUTPUT_FILE}.$i.summary
+        mv ${counts_tmp}.summary ${COUNTS_OUTPUT_FILE}.$i.testsummary
     done
 }
 


### PR DESCRIPTION
The naming for the test files generated from feature run:
Before:
strand_test.IP_24hLight1.counts.0.summary
Now:
strand_test.IP_24hLight1.counts.0.testsummary