### PR TITLE
updated bioconductor version command

### DIFF
--- a/{{cookiecutter.project_name}}/load_packages.R
+++ b/{{cookiecutter.project_name}}/load_packages.R
@@ -23,4 +23,4 @@ library(patchwork)
 sessionInfo()
 
 writeLines("")
-source("https://bioconductor.org/biocLite.R")
+BiocManager::version()


### PR DESCRIPTION
Update the way that the bioconductor version is echoed to work with R version 3.6