### PR TITLE
fix single end STAR command

### DIFF
--- a/{{cookiecutter.project_name}}/run_analysis.sh
+++ b/{{cookiecutter.project_name}}/run_analysis.sh
@@ -151,7 +151,7 @@ echo -n ${SAMPLES} | xargs -t -d ' ' -n 1 -P ${NUM_PARALLEL_JOBS} -I % bash -c \
 echo -n ${SAMPLES} | xargs -t -d ' ' -n 1 -P ${NUM_PARALLEL_JOBS} -I % bash -c \
     "map_reads % ${STAR_INDEX} ${NUM_THREADS_PER_SAMPLE} \
     \$(listFiles , ${RNASEQ_DIR}/%/*.{{cookiecutter.fastq_suffix}}) \
-    "" \
+    '""' \
     ${MAPPING_DIR} > ${LOG_DIR}/star/%.log 2>&1 "
 {% endif %}
 


### PR DESCRIPTION
added extra speech marks around empty star parameter for single end reads
Tested on a SE project and ran successfully :)