### PR TITLE
correctly retrieve species

### DIFF
--- a/{{cookiecutter.project_name}}/functions.sh
+++ b/{{cookiecutter.project_name}}/functions.sh
@@ -101,7 +101,7 @@ function detect_stranness {
     # we need to find out the correct species file for this sample, that is whichever has
     # the largest amount of assigned reads from the [0]s. See https://github.com/sidbdri/cookiecutter-de_analysis_skeleton/issues/85
     local species=`grep -H Assigned ${DIR}/*${SAMPLE_NAME}*[0].testsummary* | \
-    awk '{print $2"\t"$1}' | sort -nr | head -1 | cut -f 2 | awk -F"." '{print $4}'`
+    awk '{print $2"\t"$1}' | sort -nr | head -1 | cut -f 2 | awk -F"." '{print $3}'`
 
     local zero="$(grep -h Assigned ${DIR}/*${SAMPLE_NAME}.${species}.counts.0.testsummary* | awk '{print $2}' ) "
     local one="$(grep -h Assigned ${DIR}/*${SAMPLE_NAME}.${species}.counts.1.testsummary* | awk '{print $2}'  )"


### PR DESCRIPTION
This small change correctly gets the species from file name. This assumes that the sample name does not have any '.'s in it.

