### PR TITLE
picard strandedness check

### DIFF
--- a/{{cookiecutter.project_name}}/run_analysis.sh
+++ b/{{cookiecutter.project_name}}/run_analysis.sh
@@ -41,9 +41,16 @@ python3 -m snakemake -s Snakefile.singlespecies_analysis multiqc -j $NUM_TOTAL_T
 
 #### we check if all the sample are the same strandness settings
 #### https://github.com/sidbdri/cookiecutter-de_analysis_skeleton/issues/127
-strandness_qc=`cat ${MAIN_DIR}/multiqc_data/multiqc_picard_RnaSeqMetrics.txt | tail -n +2 | awk -F '\t' '$19<99 {print $1"\t"$19}'`
+strandedness=`head -1 strand.txt`
+strandness_qc=`cat ${MAIN_DIR}/multiqc_data/multiqc_picard_RnaSeqMetrics.txt | tail -n +2 | \
+                awk -v s=$strandedness -F '\t' '{ if (s==0 && ($19<=45 || $19>=55))
+                                                    print $1"\t"$19;
+                                                  else if (s==1 && $19>=5)
+                                                    print $1"\t"$19;
+                                                  else if (s==2 && $19<=95)
+                                                    print $1"\t"$19};'`
 if [ ! `echo -n "${strandness_qc}" | wc -l` = 0 ]; then
-    echo "Error: The following sample may have the wrong strandness setting:"
+    echo "Error: The following sample may have the wrong strandedness setting:"
     echo "${strandness_qc}"
     exit
 fi


### PR DESCRIPTION
I have implemented the logic according to [this](https://github.com/sidbdri/cookiecutter-de_analysis_skeleton/issues/127) issue. Could you please have a look? @lweasel 

I am still new to the snakemake version of the cookie-cutter so might need you review on this as well @katieemelianova . Perviously we have the strand info in the bash variable, which is now moved to the snakemake [__strand_test__](https://github.com/sidbdri/cookiecutter-de_analysis_skeleton/blob/595deefca30fb64e131abac16c6ee1e2dae32e5b/%7B%7Bcookiecutter.project_name%7D%7D/snake_functions.py#L61) function. Am I right to say that this function will write the strandedness info into a file 'strand.txt', thus, I can read this file in the project root folder from the bash script? Or is there a more appropriate way of reading snakemake variable from bash?